### PR TITLE
Fix the location of index.js for bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "test": "jest",
-    "bundle": "ncc build index.js --license licenses.txt",
+    "bundle": "ncc build lib/index.js --license licenses.txt",
     "publish-github-action": "scripts/publish-github-action.js"
   },
   "repository": {


### PR DESCRIPTION
### SUMMARY

The bundle script should point at `lib/index.js` (not `index.js`).

### DETAILS

Correct the path passed to `ncc` for bundling the GitHub Action.

### CHECKLIST
- [ ] Documentation updated (if needed)
- [ ] Unit tests exist to cover the code you are changing and validated
- [ ] Integration tests exist to cover the code you are changing and validated
