### PR TITLE
Enable publish (persistCredentials)

### DIFF
--- a/.github/azure-pipelines/publish.yaml
+++ b/.github/azure-pipelines/publish.yaml
@@ -8,6 +8,8 @@ variables:
 pool:
   vmImage: ubuntu-latest
 steps:
+  - checkout: self
+    persistCredentials: true 
   - task: NodeTool@0
     displayName: 'Use Node 12'
     inputs:


### PR DESCRIPTION
### SUMMARY

Turn on persistCredentials in the publishing checkout step.

### CHECKLIST
- [ ] Documentation updated (if needed)
- [ ] Unit tests exist to cover the code you are changing and validated
- [ ] Integration tests exist to cover the code you are changing and validated
