### PR TITLE
Make action easier to use

### DIFF
--- a/.github/azure-pipelines/_build.yaml
+++ b/.github/azure-pipelines/_build.yaml
@@ -8,7 +8,7 @@ steps:
     displayName: 'git config email'
   - script: 'git config --local user.name hbo-github-bot'
     displayName: 'git config name'
-  - script: 'npm install'
+  - script: 'npm ci'
     displayName: 'Install: pull-request-details-action'
   - script: 'npm test'
     displayName: 'Test: pull-request-details-action'

--- a/README.md
+++ b/README.md
@@ -87,4 +87,24 @@ npm install
 npm test
 ```
 
+## Debugging
+
+To test out modifications in a developer branch, create a branch in your fork, then comment out the `dist`
+line in `.gitignore`. Then you can run the `bundle` task, check in all changes, and push up your branch.
+
+```console
+git checkout -b debug
+npm run bundle
+git add .gitignore
+git add dist
+git commit -m "testing out my changes in a workflow"
+git push -u origin HEAD
+```
+
+In your GitHub workflow in another project, point at your custom branch:
+
+```yaml
+  - uses: MyForkedCopy/pull-request-details-action@debug
+```
+
 [gh action docs]: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ For example, if your workflow is triggered by event type `issue_comment`, the ev
 
 Input Name    | Required? | Description
 ----------    | --------- | -----------
-`owner`       | Yes       | user/org name of the repo containing the PR
-`repo`        | Yes       | repo name of the repo containing the PR
-`pull-number` | Yes       | PR number
-`repo-token`  | Yes       | the API token to use for access (usually GITHUB_TOKEN)
+`owner`       | No        | user/org name of the repo containing the PR (defaults to current org)
+`repo`        | No        | repo name of the repo containing the PR (defaults to current name)
+`pull-number` | No        | PR number (defaults to current PR number)
+`repo-token`  | No        | the API token to use for access (usually GITHUB_TOKEN)
 
 For example, to get the details of `PR #37` on `AcmeCorp/RocketSled`, you would pass the following inputs:
 
@@ -24,6 +24,8 @@ For example, to get the details of `PR #37` on `AcmeCorp/RocketSled`, you would 
     pull-number: 37
     repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+To retrieve the "current pull request" for an event attached to a pull request, you can skip all the inputs.
 
 ## Outputs
 
@@ -56,11 +58,6 @@ Note: to access these outputs, give the step an `id`, and use the step output va
 ```yaml
   - uses: HBOCodeLabs/pull-request-details-action@v1
     id: pull-request
-    with:
-      owner: AcmeCorp
-      repo: RocketSled
-      pull-number: 37
-      repo-token: ${{ secrets.GITHUB_TOKEN }}
   - run: echo Merging ${FROM_BRANCH} to ${TO_BRANCH}
     env:
       # Stash the outputs of pull-request-details-action in env vars
@@ -73,6 +70,10 @@ Note: to access these outputs, give the step an `id`, and use the step output va
 Note: for the versions listed below, your workflows can refer to either the version tag (`HBOCodeLabs/pull-request-details-action@v1.0.5`) or the major version branch (`HBOCodeLabs/pull-request-details-action@v1`).
 
 The major version branch may be updated with backwards-compatible features and bug fixes. Version tags will not be modified once released.
+
+#### 2021-08-04 - `v1.1.0` (`v1`)
+
+ - All inputs are now optional.
 
 #### 2021-07-09 - `v1.0.6` (`v1`)
 

--- a/README.md
+++ b/README.md
@@ -80,20 +80,20 @@ The major version branch may be updated with backwards-compatible features and b
 
 ## Contributions
 
-Pull requests welcome. To ensure tests pass locally:
+Pull requests welcome. To ensure unit tests pass locally:
 
 ```console
 npm install
 npm test
 ```
 
-## Debugging
+## Testing changes in a live workflow
 
 To test out modifications in a developer branch, create a branch in your fork, then comment out the `dist`
 line in `.gitignore`. Then you can run the `bundle` task, check in all changes, and push up your branch.
 
 ```console
-git checkout -b debug
+git checkout -b testing
 npm run bundle
 git add .gitignore
 git add dist
@@ -104,7 +104,7 @@ git push -u origin HEAD
 In your GitHub workflow in another project, point at your custom branch:
 
 ```yaml
-  - uses: MyForkedCopy/pull-request-details-action@debug
+  - uses: MyForkedCopy/pull-request-details-action@testing
 ```
 
 [gh action docs]: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions

--- a/action.yaml
+++ b/action.yaml
@@ -3,16 +3,20 @@ description: 'Retrieve branch details of an existing pull request'
 inputs:
   owner:
     description: 'user/org name'
-    required: true
+    required: false
+    default: ${{ github.event.repository.owner.login }}
   repo:
     description: 'repo name'
-    required: true
+    required: false
+    default: ${{ github.event.repository.name }}
   pull-number:
     description: 'pull request number'
-    required: true
+    required: false
+    default: ${{ github.event.issue.number }}
   repo-token:
     description: 'token to use for repo access (typically GITHUB_TOKEN)'
-    required: true
+    required: false
+    default: ${{ github.token }}
 outputs:
   base-ref:
     description: 'ref name of base branch'

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,11 +6,11 @@ const github = require('@actions/github');
 
 async function main() {
     const request = {
-        owner: core.getInput('owner'),
-        repo: core.getInput('repo'),
-        pull_number: core.getInput('pull-number')
+        owner: core.getInput('owner', { required: true }),
+        repo: core.getInput('repo', { required: true }),
+        pull_number: core.getInput('pull-number', { required: true })
     };
-    const token = core.getInput('repo-token');
+    const token = core.getInput('repo-token', { required: true });
 
     core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,11 +6,11 @@ const github = require('@actions/github');
 
 async function main() {
     const request = {
-        owner: core.getInput('owner', { required: true }),
-        repo: core.getInput('repo', { required: true }),
-        pull_number: core.getInput('pull-number', { required: true })
+        owner: core.getInput('owner'),
+        repo: core.getInput('repo'),
+        pull_number: core.getInput('pull-number')
     };
-    const token = core.getInput('repo-token', { required: true });
+    const token = core.getInput('repo-token');
 
     core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`);
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -76,12 +76,4 @@ describe('main', () => {
         expect(core.setOutput).toHaveBeenCalledWith('head-owner', 'AcmeCorp');
         expect(core.setOutput).toHaveBeenCalledWith('head-repo', 'RocketSled');
     });
-
-    it('raises an error if a required input is missing', async () => {
-        process.env['INPUT_OWNER'] = 'AcmeCorp';
-        process.env['INPUT_REPO'] = 'RocketSled';
-        process.env['INPUT_PULL-NUMBER'] = '37';
-
-        expect(main()).rejects.toThrowError('Input required and not supplied: repo-token');
-    });
 });

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -76,4 +76,12 @@ describe('main', () => {
         expect(core.setOutput).toHaveBeenCalledWith('head-owner', 'AcmeCorp');
         expect(core.setOutput).toHaveBeenCalledWith('head-repo', 'RocketSled');
     });
+
+    it('raises an error if an input ends up empty', async () => {
+        process.env['INPUT_OWNER'] = 'AcmeCorp';
+        process.env['INPUT_REPO'] = 'RocketSled';
+        process.env['INPUT_REPO-TOKEN'] = 'cafe43';
+
+        await expect(main()).rejects.toThrowError('Input required and not supplied: pull-number');
+    });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pull-request-details-action",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Retrieve the branch details of a specific pull request.",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
### SUMMARY

 - All inputs are now optional (they default to "this pull request", if that makes sense).

### DETAILS

For most use cases where the workflow executes in the context of a pull request, the action can intuit what pull request is being retrieved, so all inputs to the action are now optional.

You can still provide specific values to retrieve the details of a different PR (or to use this action in a workflow that doesn't execute in the context of a pull request).

### CHECKLIST
- [x] Documentation updated (if needed)
- [x] Unit tests exist to cover the code you are changing and validated
- [ ] Integration tests exist to cover the code you are changing and validated
