### PR TITLE
Update action to node16

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -35,5 +35,5 @@ outputs:
   head-repo:
     description: 'repo name of head branch'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Per GitHub Deprecation: https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-
node12/
